### PR TITLE
updated grunt-markdownlint dependency to markdown-it for Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "autoprefixer": "^9.8.6",
         "grunt": "^1.3.0",
-        "grunt-markdownlint": "^2.6.0",
+        "grunt-markdownlint": "^2.10.0",
         "minimist": "^1.2.5",
         "postcss-cli": "^7.1.2"
       }
@@ -5558,9 +5558,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-root": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "autoprefixer": "^9.8.6",
     "grunt": "^1.3.0",
-    "grunt-markdownlint": "^2.6.0",
+    "grunt-markdownlint": "^2.10.0",
     "minimist": "^1.2.5",
     "postcss-cli": "^7.1.2"
   }


### PR DESCRIPTION
Thank you for your contribution to the Platform-Management-Docs repo.

## Describe the changes

Updated the grunt-markdownlint dependency for the markdown-it security Dependabot alert.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Does not have conflicts with the base branch
* [ ] Is clear and complete
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Does not expose any sensitive information
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links

## Checklist for mergers

_This section is to be filled out by project maintainers only._

Before merging this PR, please make sure:

* [ ] You have applied a production label if this needs a manual push to Zoomin
* [ ] You have added it to the correct GitHub project
* [ ] You have added a new collection to Netlify CMS config (static/admin/config.js) if required (new doc sections)
* [ ] You have updated the Zoomin classification file if required (new folder of topics>
