### PR TITLE
Revert "updated grunt-markdownlint dependency to markdown-it for Dependabot alert"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "autoprefixer": "^9.8.6",
         "grunt": "^1.3.0",
-        "grunt-markdownlint": "^2.10.0",
+        "grunt-markdownlint": "^2.6.0",
         "minimist": "^1.2.5",
         "postcss-cli": "^7.1.2"
       }
@@ -5558,9 +5558,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-root": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "autoprefixer": "^9.8.6",
     "grunt": "^1.3.0",
-    "grunt-markdownlint": "^2.10.0",
+    "grunt-markdownlint": "^2.6.0",
     "minimist": "^1.2.5",
     "postcss-cli": "^7.1.2"
   }


### PR DESCRIPTION
Reverts Axway/platform-management-docs#48