### PR TITLE
Delete extra horizontal line from Netlify content pages

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -13,5 +13,5 @@
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
-	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+	{{ partial "page-meta-lastmod.html" . }}
 </div>


### PR DESCRIPTION
Thank you for your contribution to the Platform-Management-Docs repo.

## Describe the changes

After removing the Feedback section at the bottom of the Netlify page, an extra horizontal section line remained and needs to be deleted. This removes it from the "content" (2nd level heading) pages.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Does not have conflicts with the base branch
* [ ] Is clear and complete
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Does not expose any sensitive information
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links

## Checklist for mergers

_This section is to be filled out by project maintainers only._

Before merging this PR, please make sure:

* [ ] You have applied a production label if this needs a manual push to Zoomin
* [ ] You have added it to the correct GitHub project
* [ ] You have added a new collection to Netlify CMS config (static/admin/config.js) if required (new doc sections)
* [ ] You have updated the Zoomin classification file if required (new folder of topics>
