### PR TITLE
Updated the unified nav description; see if 10.5.1 release notes appear

### DIFF
--- a/content/en/docs/getting_started_with_amplify_platform_management/navigation.md
+++ b/content/en/docs/getting_started_with_amplify_platform_management/navigation.md
@@ -5,7 +5,7 @@ weight: 40
 date: 2021-08-12
 ---
 
-The Amplify Platform Management interface uses a unified top and bottom navigation. From any page in the Platform, you will see the same navigation.
+The Amplify Platform Management interface provides a unified top and bottom navigation, where you see the same elements on the top and bottom of each page Platform page.
 
 ## Top navigation
 


### PR DESCRIPTION

Thank you for your contribution to the Platform-Management-Docs repo.

## Describe the changes

The 10.5.1 release notes are in the project but now showing up and I'm checking to see if it was because the PR was merged with a future date in the front matter. Revised the unified nav description to introduce a change. 

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Does not have conflicts with the base branch
* [ ] Is clear and complete
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Does not expose any sensitive information
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links

## Checklist for mergers

_This section is to be filled out by project maintainers only._

Before merging this PR, please make sure:

* [ ] You have applied a production label if this needs a manual push to Zoomin
* [ ] You have added it to the correct GitHub project
* [ ] You have added a new collection to Netlify CMS config (static/admin/config.js) if required (new doc sections)
* [ ] You have updated the Zoomin classification file if required (new folder of topics>
