### PR TITLE
Updated references to images to be consistent to fix Zoomin display

### DIFF
--- a/content/en/docs/getting_started_with_amplify_platform_management/sign_up.md
+++ b/content/en/docs/getting_started_with_amplify_platform_management/sign_up.md
@@ -13,7 +13,9 @@ To create your account:
     ![Amplify API Management Platform overview page](/Images/amplify_platform_overiew.png)
 
 2. To proceed with creating a new {{% variables/platform_prod_name %}} account, click **Try it Now**. Clicking Try it Now forwards you to the {{% variables/platform_prod_name %}} _Create your free account_ page.
+
     ![Create your free Platform account modal](/Images/platform_sign_up_blank.png)
+
 3. Complete the following fields:
     1. **First Name**
     2. **Last Name**
@@ -28,13 +30,17 @@ To create your account:
     8. Select the **I have read and agree to the Axway Terms of Use and Privacy statement** option.
 
 4. Click **Sign up**. A message to _Check your email_ is displayed.
+
     ![Check your email dialog](/Images/check_your_email.png)
+
 5. Locate the email, and then click **Active your Account**. You should have an email similar to the following in your inbox.
 
     ![Activate your account button](/Images/activation_email.png)
 
 6. You will see a message that your account has been activated, and then you are redirected to the **Sign in to your account** page. Type your email address and  password you used to sign up, and then click **Sign In**.
+
     ![Sign in to your account page](/Images/sign_in_to_your_account.png)
+
     The {{% variables/platform_prod_name %}} home page is displayed. Refer to the [Amplify Platform Overview](/docs/getting_started_with_amplify_platform_management/overview) for details.
 
 ## Amplify Platform US and EU availability, data privacy, and data residency


### PR DESCRIPTION
Thank you for your contribution to the Platform-Management-Docs repo.

## Describe the changes

The new Zoomin doc portal was displaying an image inline instead of on a new line in a numbered step procedure. I updated the markdown for references to images in the steps to be consistent to fix the formatting in Zoomin. 

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Does not have conflicts with the base branch
* [ ] Is clear and complete
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Does not expose any sensitive information
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links

## Checklist for mergers

_This section is to be filled out by project maintainers only._

Before merging this PR, please make sure:

* [ ] You have applied a production label if this needs a manual push to Zoomin
* [ ] You have added it to the correct GitHub project
* [ ] You have added a new collection to Netlify CMS config (static/admin/config.js) if required (new doc sections)
* [ ] You have updated the Zoomin classification file if required (new folder of topics>
