### PR TITLE
APPTS 14.0.0 and prior 13.X release notes, remove Unified Catalog refs in org concepts and roles docs 

### DIFF
--- a/content/en/docs/management_guide/organizations/organization_concepts.md
+++ b/content/en/docs/management_guide/organizations/organization_concepts.md
@@ -57,10 +57,4 @@ Users can belong to one or more teams or not belong to any teams at all. A team 
 
 ![Teams page](/Images/organization_teams.png)
 
-When creating items such as API Proxies in {{% variables/central_prod_name %}} or Unified Catalog Assets one team always needs to be chosen as an owner. Only members of the owning team can make changes or remove the items. The following is an example showing the owning team of Unified Catalog items.
-
-![Unified Catalog team owners](/Images/teams_owning_team.png)
-
-Unified Catalog items can be shared with other teams. The teams need to be belong to the same organization. The other teams can then discover and consume those items, but they cannot make changes to them.
-
-![Sharing Unified Catalog items](/Images/teams_share_unified_catalog_items.png)
+When creating items such as API Proxies in {{% variables/central_prod_name %}} one team always needs to be chosen as an owner. Only members of the owning team can make changes or remove the items.

--- a/content/en/docs/management_guide/organizations/organization_roles_and_features.md
+++ b/content/en/docs/management_guide/organizations/organization_roles_and_features.md
@@ -27,10 +27,10 @@ Users also have a role in each team they belong to.
 | Team Role | Short Description | Provider | Consumer |
 | --- | --- | --- | --- |
 | Team Manager | Use this role to manage the members of the team and their role assignments | x | x |
-| Consumer | Use this role to view and consume assets in the Unified Catalog or product in the Marketplace |   | x |
-| Developer** | Use this role to manage assets in Amplify and the Unified Catalog | x |   |
+| Consumer | Use this role to view and consume products in the Marketplace |   | x |
+| Developer** | Use this role to manage assets in Amplify | x |   |
 | Marketplace Manager | Use this role to manage Marketplace settings, appearance, and content | x |   |
-| Catalog Manager** | Use this role to manage product, Unified Catalog items, and approve subscriptions and Access Requests | x |   |
+| Catalog Manager** | Use this role to manage product and approve subscriptions and Access Requests | x |   |
 | Subscriber | Use this role to manage Marketplace subscriptions and view usage |   | x |
 | Subscription Approver** | Use this role to approve Marketplace Subscriptions and Access Requests | x |   |
 
@@ -42,19 +42,6 @@ The following table shows the available team roles and capabilities. The Central
 
 | Capabilities                            | Catalog Manager         | Subscription Approver   | Subscriber              | Marketplace Manager     | Developer               | Consumer           | Team Manager            |
 | --------------------------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ------------------ | ----------------------- |
-| **Unified Catalog**                     |                         |                         |                         |                         |                         |                    |                         |
-| Create catalog items                    | x (my team)             |                         |                         |                         | x (my team)             |                    |                         |
-| View catalog items                      | x (my team)             |                         |                         |                         | x (my team)             | x                  |                         |
-| Delete catalog items                    | x (my team)             |                         |                         |                         |                         |                    |                         |
-| Share a catalog item                    | x (my team)             |                         |                         |                         |                         | x                  |                         |
-| Edit a catalog item                     | x (my team)             |                         |                         |                         | x (my team)             |                    |                         |
-| Create my subscriptions                 | x (my team)             |                         |                         |                         | x (my team)             | x (my team)        |                         |
-| View my subscriptions                   | x (my team)             |                         |                         |                         | x (my team)             | x (my team)        |                         |
-| Update my subscriptions                 | x (my team)             |                         |                         |                         | x (my team)             | x (my team)        |                         |
-| View consumer's subscriptions           | x (my team assets)      |                         |                         |                         |                         |                    |                         |
-| Delete consumer's subscriptions         | x (my team assets)      |                         |                         |                         |                         |                    |                         |
-| Approve/reject consumer's subscriptions | x (my team assets)      |                         |                         |                         |                         |                    |                         |
-| Delete my subscriptions                 | x (my team)             |                         |                         |                         | x (my team)             | x (my team)        |                         |
 | **Marketplace**                         |                         |                         |                         |                         |                         |                    |                         |
 | View products                           | x (my team)             |                         | x (my team)             |                         | x (my team)             | x (my team)        |                         |
 | Subscribe                               | x (free plan only)      |                         | x (free plan only)      |                         | x (free plan only)      | x (free plan only) |                         |

--- a/content/en/docs/release_notes/13_0_0_release_notes.md
+++ b/content/en/docs/release_notes/13_0_0_release_notes.md
@@ -51,7 +51,7 @@ __New feature__
 __Fixed issues__
 
 * Fixed an issue where organization administrators may not be able to remove a team using the action in the *Teams* table.
-* Fixed an issue where __Marketplace__ consumer organization administartors may not be able to edit their teams.
+* Fixed an issue where __Marketplace__ consumer organization administrators may not be able to edit their teams.
 
 ---
 

--- a/content/en/docs/release_notes/13_0_0_release_notes.md
+++ b/content/en/docs/release_notes/13_0_0_release_notes.md
@@ -36,7 +36,7 @@ __Fixed issues__
 
 * Fixed an issue where API Gateway Transactions usage may be incorrectly shown as unentitled on the *Usage* view.
 * Fixed an issue where the *Credentials* view may require an existing password when establishing tooling credentials and no existing password is set.
-* Fixed an issue where users that are members of multiple __Marketplace__ consumer organizations may not be redirected to the marketplace which switching between orgs.
+* Fixed an issue where users that are members of multiple __Marketplace__ consumer organizations may not be redirected to the marketplace when switching between orgs.
 
 ---
 

--- a/content/en/docs/release_notes/13_0_0_release_notes.md
+++ b/content/en/docs/release_notes/13_0_0_release_notes.md
@@ -1,12 +1,67 @@
 ---
-title: Platform Management 13.0.0 - 13.20.1 release notes
-linkTitle: Platform Management 13.0.0 - 13.20.1 release notes
+title: Platform Management 13.0.0 - 13.22.1 release notes
+linkTitle: Platform Management 13.0.0 - 13.22.1 release notes
 weight: 50
 simple_list: true
-date: 2024-06-12
+date: 2024-07-31
 ---
 
-New features, improvements, and bug fixes for releases 13.0.0 - 13.20.1.
+New features, improvements, and bug fixes for releases 13.0.0 - 13.22.1.
+
+---
+
+## 13.22.1 - 31 Jul 2024
+
+Platform Management 13.22.1 is a patch release which includes one changed behavior.
+
+__Changed behavior__
+
+* Removed ability to directly associate assets to a team on the *Team* form view. The related fields have been marked as deprecated in the API documentation and will be removed in a future release.
+
+---
+
+## 13.22.0 - 25 Jul 2024
+
+Platform Management 13.22.0 is a minor release which includes one improvement and three fixed issues.
+
+{{% alert title="Note" color="primary" %}}
+Axway is current performing improvements to usage report storage. During this period, old report history entries may be unavailable. Usage data is unaffected.
+{{% /alert %}}
+
+__Improvement__
+
+* Changed post sign-in redirection for members of organizations with no active purchases. Those users will now be redirected to *Platform Home*. The *Offerings* view has been removed.
+
+__Fixed issues__
+
+* Fixed an issue where API Gateway Transactions usage may be incorrectly shown as unentitled on the *Usage* view.
+* Fixed an issue where the *Credentials* view may require an existing password when establishing tooling credentials and no existing password is set.
+* Fixed an issue where users that are members of multiple __Marketplace__ consumer organizations may not be redirected to the marketplace which switching between orgs.
+
+---
+
+## 13.21.0 - 25 Jun 2024
+
+Platform Management 13.21.0 is a minor release which includes one new feature and two fixed issues.
+
+__New feature__
+
+* Added MyFatoorah as an available billing integration vendor on the *Marketplace Billing* settings.
+
+__Fixed issues__
+
+* Fixed an issue where organization administrators may not be able to remove a team using the action in the *Teams* table.
+* Fixed an issue where __Marketplace__ consumer organization administartors may not be able to edit their teams.
+
+---
+
+## 13.20.2 - 18 Jun 2024
+
+Platform Management 13.20.2 is a patch release which includes one fixed issue.
+
+__Fixed issues__
+
+* Fixed an issue where users which authenticate using their organization's identity provider may not be able to establish tooling credentials on the *Credentials* view.
 
 ---
 
@@ -165,7 +220,7 @@ __Improvement__
 Platform Management 13.15.1 is a patch release which includes one new feature.
 
 {{% alert title="Note" color="primary" %}}
-With this release, organizations which are currently entitled to access Unified Catalog have been granted an __Amplify Enterprise Marketplace__ subscription.
+With this release, organizations which were previously entitled to access Unified Catalog have been granted an __Amplify Enterprise Marketplace__ subscription.
 {{% /alert %}}
 
 __New feature__

--- a/content/en/docs/release_notes/14_0_0_release_notes.md
+++ b/content/en/docs/release_notes/14_0_0_release_notes.md
@@ -1,0 +1,25 @@
+---
+title: Platform Management 14.0.0 release notes
+linkTitle: Platform Management 14.0.0 release notes
+weight: 49
+simple_list: true
+date: 2024-08-08
+---
+
+New features, improvements, and bug fixes for release 14.0.0.
+
+---
+
+## 14.0.0 - 8 Aug 2024
+
+Platform Management 14.0.0 is a major release which includes two fixed issues.
+
+{{% alert title="Note" color="primary" %}}
+With this release, all navigation elements, *Platform Home* tasks and capabilities, and metrics on the *Overview* page related to __Unified Catalog__ have been removed.
+{{% /alert %}}
+
+
+__Fixed issue__
+
+* Fixed an issue where the organization *Users* table may show an incorrect date of creation for certain users which have been migrated from older __Support Portal__ accounts.
+* Fixed an issue where an authentication attempt which fails due to expiry of its grant may cause the user to be shown an unformatted error message.

--- a/content/en/docs/release_notes/14_0_0_release_notes.md
+++ b/content/en/docs/release_notes/14_0_0_release_notes.md
@@ -18,7 +18,6 @@ Platform Management 14.0.0 is a major release which includes two fixed issues.
 With this release, all navigation elements, *Platform Home* tasks and capabilities, and metrics on the *Overview* page related to __Unified Catalog__ have been removed.
 {{% /alert %}}
 
-
 __Fixed issue__
 
 * Fixed an issue where the organization *Users* table may show an incorrect date of creation for certain users which have been migrated from older __Support Portal__ accounts.

--- a/content/en/docs/release_notes/14_0_0_release_notes.md
+++ b/content/en/docs/release_notes/14_0_0_release_notes.md
@@ -18,7 +18,7 @@ Platform Management 14.0.0 is a major release which includes two fixed issues.
 With this release, all navigation elements, *Platform Home* tasks and capabilities, and metrics on the *Overview* page related to __Unified Catalog__ have been removed.
 {{% /alert %}}
 
-__Fixed issue__
+__Fixed issues__
 
 * Fixed an issue where the organization *Users* table may show an incorrect date of creation for certain users which have been migrated from older __Support Portal__ accounts.
 * Fixed an issue where an authentication attempt which fails due to expiry of its grant may cause the user to be shown an unformatted error message.


### PR DESCRIPTION
Thank you for your contribution to the Platform-Management-Docs repo.

## Describe the changes

APPTS 14.0.0 and prior 13.X release notes, remove Unified Catalog refs in org concepts and roles docs 

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Does not have conflicts with the base branch
* [ ] Is clear and complete
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Does not expose any sensitive information
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links

## Checklist for mergers

_This section is to be filled out by project maintainers only._

Before merging this PR, please make sure:

* [ ] You have applied a production label if this needs a manual push to Zoomin
* [ ] You have added it to the correct GitHub project
* [ ] You have added a new collection to Netlify CMS config (static/admin/config.js) if required (new doc sections)
* [ ] You have updated the Zoomin classification file if required (new folder of topics>
